### PR TITLE
Update URL to installation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Download the Blockpool install script
 
-http://www.blockpool.io/Blockpool_Node/BPL_Node_Install_Script.sh
+https://github.com/blockpool-io/BPL-node/blob/bpl-mainnet/BPL_Node_Install_Script.sh
 
 Open up your terminal
 ./BPL_Node_Install_Script.sh


### PR DESCRIPTION
URL currently in use is for an out of date version of the file, which contains some undesirable commands.