### PR TITLE
adds block id to json returned by shared.getStatus

### DIFF
--- a/modules/blocks.js
+++ b/modules/blocks.js
@@ -1706,11 +1706,12 @@ shared.getStatus = function (req, cb) {
 	var counter = 0;
 
 	var status = {
-		epoch:     constants.epochTime,
-		height:    block.height,
-		fee:       library.logic.block.calculateFee(),
-		milestone: __private.blockReward.calcMilestone(block.height),
-		nethash:   library.config.nethash,
+		epoch:       constants.epochTime,
+		height:      block.height,
+		lastBlockId: block.id,
+		fee:         library.logic.block.calculateFee(),
+		milestone:   __private.blockReward.calcMilestone(block.height),
+		nethash:     library.config.nethash,
 	};
 
 	__private.blockReward.calcRewardForHeight(modules.blockchain.getLastBlock().height,function(error, details) {

--- a/test/api/blocks.js
+++ b/test/api/blocks.js
@@ -117,6 +117,7 @@ describe('GET /api/blocks/getStatus', function () {
 			node.expect(res.body).to.have.property('success').to.be.ok;
 			node.expect(res.body).to.have.property('epoch').to.be.a('string');
 			node.expect(res.body).to.have.property('height').to.be.a('number');
+			node.expect(res.body).to.have.property('id').to.be.a('number');
 			node.expect(res.body).to.have.property('fee').to.be.a('number');
 			node.expect(res.body).to.have.property('milestone').to.be.a('number');
 			node.expect(res.body).to.have.property('nethash').to.be.a('string');


### PR DESCRIPTION
the block id of the latest block id gets added to the resulting json. the id can be used to link to the block in the price ticker.

the price ticker in the header of the explorer seems to be the only place using that function.